### PR TITLE
Update jalp_syslog_metadata_xml.c

### DIFF
--- a/src/producer_lib/src/jalp_journal_metadata_xml.c
+++ b/src/producer_lib/src/jalp_journal_metadata_xml.c
@@ -55,11 +55,10 @@ enum jal_status jalp_journal_metadata_to_elem(
 
 	if (journal->file_info) {
 		xmlNodePtr tmp = NULL;
-		ret = jalp_file_info_to_elem(journal->file_info, doc, &tmp);
+		ret = jalp_file_info_to_elem(journal->file_info, jmeta_element, &tmp);
 		if (ret != JAL_OK) {
 			goto cleanup;
 		}
-		xmlAddChild(jmeta_element, tmp);
 	} else {
 		ret = JAL_E_INVAL_FILE_INFO;
 		goto cleanup;

--- a/src/producer_lib/src/jalp_syslog_metadata_xml.c
+++ b/src/producer_lib/src/jalp_syslog_metadata_xml.c
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include <inttypes.h> /* PRIdMax*/
 #include <unistd.h>
+#include <string.h>
 
 #include <jalop/jalp_context.h>
 #include <jalop/jal_namespaces.h>
@@ -114,12 +115,8 @@ enum jal_status jalp_syslog_metadata_to_elem(
 		xmlSetProp(syslog_element, (xmlChar *)JALP_XML_MESSAGE_ID, xml_message_id);
 	}
 	if (syslog->entry) {
-		xmlNodePtr tmp = xmlNewChild(doc, NULL,
-						(xmlChar *)JALP_XML_ENTRY,
-						NULL);
-		xmlAddChild(syslog_element, tmp);
-		xmlChar *xml_entry = (xmlChar *)syslog->entry;
-		xmlNodeAddContent(tmp, xml_entry);
+		xmlNodePtr tmp = xmlNewChild(syslog_element, NULL,(xmlChar *)JALP_XML_ENTRY, NULL);
+		xmlAddChild(tmp,xmlNewCDataBlock(NULL, (xmlChar*)syslog->entry, strlen(syslog->entry)));
 	}
 	if (syslog->sd_head) {
 		struct jalp_structured_data *curr = syslog->sd_head;

--- a/src/producer_lib/src/jalp_syslog_metadata_xml.c
+++ b/src/producer_lib/src/jalp_syslog_metadata_xml.c
@@ -122,7 +122,7 @@ enum jal_status jalp_syslog_metadata_to_elem(
 		struct jalp_structured_data *curr = syslog->sd_head;
 		while (curr) {
 			xmlNodePtr tmp = NULL;
-			ret = jalp_structured_data_to_elem(curr, doc, &tmp);
+			ret = jalp_structured_data_to_elem(curr, syslog_element, &tmp);
 			if (ret != JAL_OK) {
 				goto cleanup;
 			}


### PR DESCRIPTION
I found a problem.

In jalop2.0.0.5-beta/jalp_syslog_metadata_xml.c (line 116) it was creating the "Entry" element the wrong way.

-------old---------
xmlNodePtr tmp = xmlNewChild(doc, NULL, (xmlChar *)JALP_XML_ENTRY, NULL);
xmlAddChild(syslog_element, tmp);
xmlChar *xml_entry = (xmlChar *)syslog->entry;
xmlNodeAddContent(tmp, xml_entry);

------fix------------
xmlNodePtr tmp = xmlNewChild(syslog_element, NULL,(xmlChar *)JALP_XML_ENTRY, NULL);
xmlAddChild(tmp,xmlNewCDataBlock(NULL, (xmlChar*)syslog->entry, strlen(syslog->entry)));


The old was producing this with extra Entry Element under ApplicationMetadata:
<?xml version="1.0"?>

<jamt:ApplicationMetadata xmlns:jamt="http://www.dod.mil/jalop-1.0/applicationMetadataTypes" JID="UUID-cd899f25-7ccf-4c62-ba15-06063c8fd86c">

  <jamt:Syslog ProcessID="32045" Hostname="vbox.cubicxds.internal" ApplicationName="rsyslogd" Facility="21" Severity="6" Timestamp="2021-03-31T21:51:12" MessageID="-">

    <jamt:Entry> howdy3</jamt:Entry>

  </jamt:Syslog>

  <jamt:Entry> howdy3</jamt:Entry>

</jamt:ApplicationMetadata>

 

The new produces this without extra element. I also encased the entry in a CDATA block, maybe that is not needed:

<?xml version="1.0"?>

<jamt:ApplicationMetadata xmlns:jamt="http://www.dod.mil/jalop-1.0/applicationMetadataTypes" JID="UUID-ff2d19c2-83da-46b2-b39f-6cc2e2e826ad">

  <jamt:Syslog ProcessID="27403" Hostname="vbox.cubicxds.internal" ApplicationName="rsyslogd" Facility="21" Severity="6" Timestamp="2021-04-01T18:12:10" MessageID="-">

    <jamt:Entry><![CDATA[ <<<<<<hello<<world<<</>>]]></jamt:Entry>

  </jamt:Syslog>

</jamt:ApplicationMetadata>
